### PR TITLE
Luciano

### DIFF
--- a/FRONTEND/Dashboard/index.html
+++ b/FRONTEND/Dashboard/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
 
 <head>
-    <base href="/Dashboard/">
+<!--     <base href="/Dashboard/"> -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ELEVÉ - Gestión de Peluquería</title>

--- a/FRONTEND/Reservas/css/styles.css
+++ b/FRONTEND/Reservas/css/styles.css
@@ -708,7 +708,6 @@ img { display: block; max-width: 100%; }
   align-items: start;
 }
 
-.contacto-info { /* columna izquierda */ }
 
 .contacto-mapa {
   border-radius: 16px;

--- a/FRONTEND/Reservas/css/styles.css
+++ b/FRONTEND/Reservas/css/styles.css
@@ -213,7 +213,156 @@ img { display: block; max-width: 100%; }
   padding: 1.5rem;
   overflow: visible;
   position: relative;
+  transition: background 0.5s ease, color 0.5s ease;
 }
+
+/* Tema claro al confirmar reserva */
+.reserva-panel--confirmada {
+  background: #f8f7f5;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ---------------------------------------------------------------
+   PANTALLA DE CONFIRMACIÓN
+--------------------------------------------------------------- */
+.confirmacion-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem 0;
+  animation: fd 0.4s ease forwards;
+}
+
+.confirmacion__icono {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: #111;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.4rem;
+  flex-shrink: 0;
+  animation: confirmacion-pop 0.55s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes confirmacion-pop {
+  0%   { transform: scale(0.3); opacity: 0; }
+  65%  { transform: scale(1.1); }
+  100% { transform: scale(1);   opacity: 1; }
+}
+
+.confirmacion__icono svg {
+  width: 26px;
+  height: 26px;
+  stroke: #fff;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  stroke-dasharray: 32;
+  stroke-dashoffset: 32;
+  animation: dibujar-check 0.35s 0.38s ease forwards;
+}
+
+@keyframes dibujar-check {
+  to { stroke-dashoffset: 0; }
+}
+
+.confirmacion__titulo {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #111;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.3rem;
+}
+
+.confirmacion__sub {
+  font-size: 0.77rem;
+  color: #999;
+  line-height: 1.55;
+  margin-bottom: 1.5rem;
+}
+
+.confirmacion__detalle {
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 10px;
+  padding: 0.95rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.42rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.07);
+  text-align: left;
+}
+
+.confirmacion__fila {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.confirmacion__lbl {
+  font-size: 0.71rem;
+  color: #999;
+}
+
+.confirmacion__val {
+  font-size: 0.79rem;
+  font-weight: 500;
+  color: #111;
+  text-align: right;
+}
+
+.confirmacion__sep {
+  height: 1px;
+  background: #efefef;
+  margin: 0.05rem 0;
+}
+
+.confirmacion__total-fila {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 0.6rem;
+  border-top: 1px dashed #ddd;
+  margin-top: 0.15rem;
+}
+
+.confirmacion__total-lbl {
+  font-size: 0.71rem;
+  font-weight: 600;
+  color: #666;
+}
+
+.confirmacion__precio {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #111;
+}
+
+.btn-nueva-reserva {
+  width: 100%;
+  padding: 0.72rem 1rem;
+  background: #111;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.83rem;
+  font-weight: 600;
+  letter-spacing: 0.025em;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+  font-family: inherit;
+}
+
+.btn-nueva-reserva:hover { opacity: 0.8; }
 
 .reserva-panel::-webkit-scrollbar { display: none; }
 
@@ -321,7 +470,19 @@ img { display: block; max-width: 100%; }
   gap: 0.4rem;
 }
 
-.fechas-grid,
+.fechas-grid {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+}
+
+.fechas-grid .tarjeta {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
 .horarios-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
@@ -654,7 +815,7 @@ img { display: block; max-width: 100%; }
   /* Reserva: imagen izquierda 42%, formulario derecho 58% */
   .reserva-card {
     flex-direction: row;
-    height: 600px;
+    height: 580px;
     min-height: unset;
     max-height: unset;
   }

--- a/FRONTEND/Reservas/index.html
+++ b/FRONTEND/Reservas/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
 
 <head>
-  <base href="/Reservas/">
+<!--   <base href="/Reservas/"> -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="format-detection" content="telephone=no">
@@ -161,6 +161,17 @@
               </div>
             </div>
             <button class="btn-confirmar" id="btn-confirmar-reserva">Confirmar reserva</button>
+          </div>
+
+          <!-- Pantalla de confirmación -->
+          <div class="confirmacion-screen" id="confirmacion-screen" style="display:none">
+            <div class="confirmacion__icono">
+              <svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+            <h2 class="confirmacion__titulo">¡Turno confirmado!</h2>
+            <p class="confirmacion__sub">Te esperamos. Recordá llegar<br>unos minutos antes.</p>
+            <div class="confirmacion__detalle" id="confirmacion-detalle"></div>
+            <button class="btn-nueva-reserva" id="btn-nueva-reserva">Hacer otra reserva</button>
           </div>
 
         </div><!-- /reserva-panel -->

--- a/FRONTEND/Reservas/js/reserva.js
+++ b/FRONTEND/Reservas/js/reserva.js
@@ -32,15 +32,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('btn-continuar').addEventListener('click', guardarDatosCliente);
   document.getElementById('btn-confirmar-reserva').addEventListener('click', async () => {
+    const btn = document.getElementById('btn-confirmar-reserva');
+    btn.disabled = true;
+    btn.textContent = 'Confirmando reserva...';
+
     const turnoCreado = await crearTurno();
     if (turnoCreado) {
-      mostrarConfirmacion();
-      irAPaso(1);
-      resetearReserva();
+      mostrarPasoConfirmado();
+    } else {
+      btn.disabled = false;
+      btn.textContent = 'Confirmar reserva';
     }
   });
 
   document.querySelectorAll('.btn-volver').forEach(btn => btn.addEventListener('click', volver));
+  document.getElementById('btn-nueva-reserva').addEventListener('click', volver);
   configurarValidacionFormulario();
 });
 
@@ -55,7 +61,7 @@ function generarFechasDisponibles() {
     fecha.setDate(hoy.getDate() + i);
     if (fecha.getDay() === 0) continue; // sin domingos
     fechasDisponibles.push(fecha.toISOString().split('T')[0]);
-    if (fechasDisponibles.length === 7) break;
+    if (fechasDisponibles.length === 6) break;
   }
 }
 
@@ -363,36 +369,53 @@ function guardarDatosCliente() {
 }
 
 // ---------------------------------------------------------------
-// CONFIRMACIÓN VISUAL
+// CONFIRMACIÓN VISUAL (in-place en paso 6)
 // ---------------------------------------------------------------
-function mostrarConfirmacion() {
-  const panel = document.querySelector('.reserva-panel');
-  const msg = document.createElement('div');
-  msg.style.cssText = `
-    position: absolute; inset: 0;
-    background: white;
-    display: flex; flex-direction: column;
-    align-items: center; justify-content: center;
-    gap: 1rem; border-radius: 16px;
-    text-align: center; padding: 2rem;
-    animation: fadeSlide 0.3s ease;
-    z-index: 10;
+let reservaConfirmada = false;
+
+function mostrarPasoConfirmado() {
+  reservaConfirmada = true;
+  const r = reservaActual;
+
+  // Cambiar tema del panel
+  document.querySelector('.reserva-panel').classList.add('reserva-panel--confirmada');
+
+  // Ocultar barra de progreso y paso-6
+  document.querySelector('.progreso').style.display = 'none';
+  document.getElementById('paso-6').style.display = 'none';
+
+  // Rellenar datos de la confirmación
+  document.getElementById('confirmacion-detalle').innerHTML = `
+    <div class="confirmacion__fila">
+      <span class="confirmacion__lbl">Nombre</span>
+      <span class="confirmacion__val">${r.cliente.nombre}</span>
+    </div>
+    <div class="confirmacion__sep"></div>
+    <div class="confirmacion__fila">
+      <span class="confirmacion__lbl">Servicio</span>
+      <span class="confirmacion__val">${r.servicio}</span>
+    </div>
+    <div class="confirmacion__fila">
+      <span class="confirmacion__lbl">Barbero</span>
+      <span class="confirmacion__val">${r.barbero}</span>
+    </div>
+    <div class="confirmacion__sep"></div>
+    <div class="confirmacion__fila">
+      <span class="confirmacion__lbl">Fecha</span>
+      <span class="confirmacion__val">${formatearFecha(r.fecha)}</span>
+    </div>
+    <div class="confirmacion__fila">
+      <span class="confirmacion__lbl">Hora</span>
+      <span class="confirmacion__val">${r.hora_inicio}</span>
+    </div>
+    <div class="confirmacion__total-fila">
+      <span class="confirmacion__total-lbl">Total</span>
+      <span class="confirmacion__precio">$${r.total.toLocaleString('es-AR')}</span>
+    </div>
   `;
-  msg.innerHTML = `
-    <div style="font-size:2.5rem;line-height:1">✓</div>
-    <h2 style="font-size:1.2rem;font-weight:700;color:#111">¡Turno confirmado!</h2>
-    <p style="font-size:0.85rem;color:#777;max-width:260px">
-      ${reservaActual.servicio} con ${reservaActual.barbero}<br>
-      el ${formatearFecha(reservaActual.fecha)} a las ${reservaActual.hora_inicio}.
-    </p>
-  `;
-  panel.style.position = 'relative';
-  panel.appendChild(msg);
-  setTimeout(() => {
-    msg.style.opacity = '0';
-    msg.style.transition = 'opacity 0.4s';
-    setTimeout(() => msg.remove(), 400);
-  }, 3500);
+
+  // Mostrar pantalla de confirmación
+  document.getElementById('confirmacion-screen').style.display = 'flex';
 }
 
 function resetearReserva() {
@@ -428,6 +451,31 @@ function irAPaso(numero) {
 }
 
 function volver() {
+  // Si la reserva ya fue confirmada, volver al paso 1 y resetear todo
+  if (reservaConfirmada) {
+    reservaConfirmada = false;
+
+    // Ocultar pantalla de confirmación
+    document.getElementById('confirmacion-screen').style.display = 'none';
+
+    // Restaurar panel al tema oscuro
+    document.querySelector('.reserva-panel').classList.remove('reserva-panel--confirmada');
+
+    // Restaurar progreso y paso-6
+    document.querySelector('.progreso').style.display = '';
+    document.getElementById('paso-6').style.display = '';
+
+    // Restaurar botón confirmar
+    const btnConfirmar = document.getElementById('btn-confirmar-reserva');
+    btnConfirmar.style.display = '';
+    btnConfirmar.disabled = false;
+    btnConfirmar.textContent = 'Confirmar reserva';
+
+    resetearReserva();
+    irAPaso(1);
+    return;
+  }
+
   if (pasoActual <= 1) return;
 
   // Limpiar datos del paso actual al retroceder


### PR DESCRIPTION

Reemplaza el cambio de colores en el wizard por una pantalla de éxito
dedicada que se muestra al confirmar el turno.

- `index.html` — agrega `#confirmacion-screen` con icono, datos y CTA
- `styles.css` — panel tema claro + componente confirmacion
- `reserva.js` — `mostrarPasoConfirmado()` oculta el wizard y renderiza
  los datos del turno; `volver()` / "Hacer otra reserva" restaura el
  estado oscuro y resetea al paso 1
- Card blanca con los datos confirmados (servicio, barbero, fecha, hora, total)
- Botón "Hacer otra reserva" para reiniciar el flujo